### PR TITLE
bugfix: to.Params can be nil

### DIFF
--- a/pkg/invite/session.go
+++ b/pkg/invite/session.go
@@ -77,7 +77,7 @@ func NewInviteSession(edp *endpoint.EndPoint, uaType string, contact *sip.Contac
 	to, _ := req.To()
 	from, _ := req.From()
 
-	if !to.Params.Has("tag") {
+	if to.Params != nil && !to.Params.Has("tag") {
 		to.Params.Add("tag", sip.String{Str: util.RandString(8)})
 		req.RemoveHeader("To")
 		req.AppendHeader(to)


### PR DESCRIPTION
我写了一个 sip server，使用 go-sip-ua 库（感谢作者🙏），
在 sip server 主动发起 Invite 时，引发错误，定位到是 to.Params 为 nil 的问题。

```go

// Invite .
func (s *SipServer) Invite(client string) error {
	aor, ok := s.clients[client]
	if !ok {
		return fmt.Errorf("client %s not exist", client)
	}

	contacts, err := s.registry.GetContacts(aor)
	if err != nil {
		return fmt.Errorf("aor %v not exist", aor)
	}

	profile := account.NewProfile(s.user, "",
		&account.AuthInfo{
			AuthName: "100",
			Password: "100",
			Realm:    "",
		},
		1800,
	)

	for _, instance := range *contacts {
		user := aor.User().String()
		target, err := parser.ParseSipUri("sip:" + user + "@" + instance.Source + ";transport=" + instance.Transport)
		if err != nil {
			log.Error(err)
		}
		sdp := s.getSDP(client)
		s.ua.Invite(profile, sip.SipUri{
			FUser:      sip.String{Str: user},
			FHost:      target.Host(),
			FPort:      target.Port(),
			FUriParams: target.UriParams(),
		}, &sdp)
	}

	return nil
}
```