### PR TITLE
handle branches and reinvites properly

### DIFF
--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -16,6 +16,16 @@ var (
 	ErrPort       = errors.New("invalid port")
 )
 
+func GetBranchID(request sip.Request) sip.MaybeString {
+	if viaHop, ok := request.ViaHop(); ok {
+		if branch, ok := viaHop.Params.Get("branch"); ok {
+			return branch
+		}
+	}
+
+	return nil
+}
+
 func GetIP(addr string) string {
 	if strings.Contains(addr, ":") {
 		return strings.Split(addr, ":")[0]


### PR DESCRIPTION
This PR should store unique branches as different transactions (by creating a compound key for the session store) allowing multi-branch support. It also addresses reINVITEs so that they are identified using a "to" header tag instead of simply by receipt of a duplicate INVITE.