### PR TITLE
Fix authorization nc(nonce count) hex error

### DIFF
--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -97,7 +97,7 @@ func (auth *Authorization) CalcResponse(request sip.Request) *Authorization {
 	auth.nc += 1
 	hex := fmt.Sprintf("%x", auth.nc)
 	ncHex := "00000000"
-	auth.ncHex = ncHex[:len(ncHex)-1-len(hex)] + hex
+	auth.ncHex = ncHex[:len(ncHex)-len(hex)] + hex
 	// Nc-value = 8LHEX. Max value = 'FFFFFFFF'.
 	if auth.nc == 4294967296 {
 		auth.nc = 1


### PR DESCRIPTION
First of all, thanks for the awesome opensource project!
During using go-sip-ua, I found an error on authorization nc(nonce count) generation process.

As you commented on `pkg/auth/client.go` 101Line, Nc-value should be 8LHEX.
But the logic actually generates 7LHEX.
For example, if `auth.nc` is 1, `auth.ncHex = ncHex[:len(ncHex)-1-len(hex)] + hex`.
This equals to `auth.ncHex = ncHex[:8-1-1] + hex`, so `auth.ncHex = "0000001"` as result.

So I simply fix this line and send PR to you, please check 🙏 