### PR TITLE
Avoid overflow int for arm architecture

### DIFF
--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -99,7 +99,7 @@ func (auth *Authorization) CalcResponse(request sip.Request) *Authorization {
 	ncHex := "00000000"
 	auth.ncHex = ncHex[:len(ncHex)-len(hex)] + hex
 	// Nc-value = 8LHEX. Max value = 'FFFFFFFF'.
-	if auth.nc == 4294967296 {
+	if temp_nc := int64(auth.nc); temp_nc == 4294967296 {
 		auth.nc = 1
 		auth.ncHex = "00000001"
 	}


### PR DESCRIPTION
## Reason
`auth.nc` with the int type creates **overflow int** once building for `arm` architecture ( in my case Raspberry Pi 3) ## Solution
Typecasting `auth.nc` for the `if` clause.