### PR TITLE
Fixed incorrect authorization when multiple qop methods are available

### DIFF
--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -47,7 +47,7 @@ func AuthFromValue(value string) *Authorization {
 		value2 := strings.Replace(match[2], "\"", "", -1)
 		switch match[1] {
 		case "qop":
-			auth.qop = value2
+			auth.qop = strings.Split(value2, ",")[0]
 		case "realm":
 			auth.realm = value2
 		case "algorithm":


### PR DESCRIPTION
If the server offers multiple digest authorization methods in qop, the client mistakenly takes the entire string as a qop method.

Behavior before fix
```
REGISTER sip:sipserver.com:5060 SIP/2.0
Via: SIP/2.0/UDP 172.25.0.2:5090;branch=z9hG4bK.f5FLszLABxpfKjbpKOkdogcIX2JbmwnK
CSeq: 1 REGISTER
From: <sip:703@sipserver.com>;tag=uIgQC1wP
To: <sip:703@sipserver.com>
Call-ID: bvB5AZW1Mqd4siMo2uCX5x1FrleIWGXj
Contact: <sip:703@172.25.0.2:5090;transport=udp>;+sip.instance="<urn:uuid:78cccaa5-82f1-11ed-90e1-0242ac190002>"
Max-Forwards: 70
Content-Length: 0
Expires: 180
Allow: INVITE, ACK, BYE, CANCEL, INFO, OPTIONS, UPDATE
Supported: replaces, outbound

SIP/2.0 401 Unauthorized
Via: SIP/2.0/UDP 172.25.0.2:5090;branch=z9hG4bK.f5FLszLABxpfKjbpKOkdogcIX2JbmwnK;received=109.248.34.252;rport=5090
From: <sip:703@sipserver.com>;tag=uIgQC1wP
To: <sip:703@sipserver.com>;tag=ecssR16718210528448770119290
Call-ID: bvB5AZW1Mqd4siMo2uCX5x1FrleIWGXj
CSeq: 1 REGISTER
WWW-Authenticate: Digest realm="sipserver.com", qop="auth,auth-int", nonce="adcbcddfe1ec5a11bd78b0e5e17c2e92", algorithm=MD5
User-Agent: Eltex ECSS-10 SIP 3.14.9.628
Content-Length: 0

REGISTER sip:sipserver.com:5060 SIP/2.0
Via: SIP/2.0/UDP 172.25.0.2:5090;branch=z9hG4bK.ZUiofzXgclkwrVn3oMMCqGWca1coao0k
CSeq: 2 REGISTER
From: <sip:703@sipserver.com>;tag=uIgQC1wP
To: <sip:703@sipserver.com>
Call-ID: bvB5AZW1Mqd4siMo2uCX5x1FrleIWGXj
Contact: <sip:703@172.25.0.2:5090;transport=udp>;+sip.instance="<urn:uuid:78cccaa5-82f1-11ed-90e1-0242ac190002>"
Max-Forwards: 70
Content-Length: 0
Expires: 180
Allow: INVITE, ACK, BYE, CANCEL, INFO, OPTIONS, UPDATE
Supported: replaces, outbound
Authorization: Digest realm="sipserver.com",algorithm=MD5,nonce="adcbcddfe1ec5a11bd78b0e5e17c2e92",username="703",uri="sip:ssw.aicall
u:5060",response="df453492a6ac499f2a15cb050c980c44",qop="auth,auth-int",cnonce="2b42f64e176ecbd4e464b27c",nc="00000001"
User-Agent: Go Sip Client/example-client
```
And after fix
```
REGISTER sip:sipserver.com:5060 SIP/2.0
Via: SIP/2.0/UDP 192.168.1.138:5080;branch=z9hG4bK.AkHwyNeZs0pDhsiswd7c6BPaIY4L79co
CSeq: 1 REGISTER
From: <sip:703@sipserver.com>;tag=KL79rC9S
To: <sip:703@sipserver.com>
Call-ID: dTmXehsvF2ZyvNjF3pJLOrHLoCQg6qQd
Contact: <sip:703@192.168.1.138:5080;transport=udp>;+sip.instance="<urn:uuid:07aa63f4-82ca-11ed-8413-acde48001122>"
Max-Forwards: 70
Content-Length: 0
Expires: 1800
Allow: INVITE, ACK, BYE, CANCEL, INFO, OPTIONS, UPDATE
Supported: replaces, outbound
User-Agent: Go Sip Client/example-client

SIP/2.0 401 Unauthorized
Via: SIP/2.0/UDP 192.168.1.138:5080;branch=z9hG4bK.AkHwyNeZs0pDhsiswd7c6BPaIY4L79co;received=109.248.34.252;rport=5080
From: <sip:703@sipserver.com>;tag=KL79rC9S
To: <sip:703@sipserver.com>;tag=ecssR16718039807932120119290
Call-ID: dTmXehsvF2ZyvNjF3pJLOrHLoCQg6qQd
CSeq: 1 REGISTER
WWW-Authenticate: Digest realm="sipserver.com", qop="auth,auth-int", nonce="c53c24d30dfbc4ccef6b360cd7306cae", algorithm=MD5
User-Agent: Eltex ECSS-10 SIP 3.14.9.628
Content-Length: 0

REGISTER sip:sipserver.com:5060 SIP/2.0
Via: SIP/2.0/UDP 192.168.1.138:5080;branch=z9hG4bK.bvmBTjDi7G3En9BRDXZQ64Qr3hk32ctI
CSeq: 2 REGISTER
From: <sip:703@sipserver.com>;tag=KL79rC9S
To: <sip:703@sipserver.com>
Call-ID: dTmXehsvF2ZyvNjF3pJLOrHLoCQg6qQd
Contact: <sip:703@192.168.1.138:5080;transport=udp>;+sip.instance="<urn:uuid:07aa63f4-82ca-11ed-8413-acde48001122>"
Max-Forwards: 70
Content-Length: 0
Expires: 1800
Allow: INVITE, ACK, BYE, CANCEL, INFO, OPTIONS, UPDATE
Supported: replaces, outbound
Authorization: Digest realm="sipserver.com",algorithm=MD5,nonce="c53c24d30dfbc4ccef6b360cd7306cae",username="703",uri="sip:ssw.aicall
u:5060",response="0bf62368d70544eed1a9e4717df7a5e3",qop="auth",cnonce="811e7d191f115fa51d5f74fb",nc="00000001"
User-Agent: Go Sip Client/example-client
```