### PR TITLE
Use From tag for matching session on BYE request

### DIFF
--- a/pkg/ua/ua.go
+++ b/pkg/ua/ua.go
@@ -234,12 +234,12 @@ func (ua *UserAgent) handleBye(request sip.Request, tx sip.ServerTransaction) {
 
 	tx.Respond(response)
 	callID, ok := request.CallID()
-	toHeader, ok2 := request.To()
+	fromHeader, ok2 := request.From()
 	if ok && ok2 {
-		toTag, _ := toHeader.Params.Get("tag")
-		if v, found := ua.iss.Load(NewSessionKey(*callID, toTag)); found {
+		fromTag, _ := fromHeader.Params.Get("tag")
+		if v, found := ua.iss.Load(NewSessionKey(*callID, fromTag)); found {
 			is := v.(*session.Session)
-			ua.iss.Delete(NewSessionKey(*callID, toTag))
+			ua.iss.Delete(NewSessionKey(*callID, fromTag))
 			var transaction sip.Transaction = tx.(sip.Transaction)
 			ua.handleInviteState(is, &request, &response, session.Terminated, &transaction)
 		}


### PR DESCRIPTION
Hi! Thanks for this useful project.
I am facing the problem of not being able to handle session termination when receiving a BYE request.
I found that the CallId + **From tag** pair is used everywhere to identify a session, but only when processing a BYE request the CallId + **To tag** pair is used.
So it becomes absolutely impossible to associate a BYE request with a session.

This behavior was introduced in https://github.com/cloudwebrtc/go-sip-ua/pull/95
Maybe @UserAd has some comments on this?