### PR TITLE
Add "rport" in via to support NAT.

### DIFF
--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -291,7 +291,7 @@ func (s *SipStack) handleRequest(req sip.Request, tx sip.ServerTransaction) {
 	go handler(req, tx)
 }
 
-//Request Send SIP message
+// Request Send SIP message
 func (s *SipStack) Request(req sip.Request) (sip.ClientTransaction, error) {
 	if !s.running.IsSet() {
 		return nil, fmt.Errorf("can not send through stopped server")
@@ -378,6 +378,7 @@ func (s *SipStack) prepareRequest(req sip.Request) sip.Request {
 			ProtocolName:    "SIP",
 			ProtocolVersion: "2.0",
 			Params: sip.NewParams().
+				Add("rport", nil).
 				Add("branch", sip.String{Str: sip.GenerateBranch()}),
 		}
 


### PR DESCRIPTION
In current version of code, the "Via" in register request looks like:
`Via: SIP/2.0/UDP 192.168.1.100:50001;branch=z9hG4bK.iJM9FQ5m5ZRW0ZJZTAvNGlTyN9JPA6Nl`
In a common VoIP software, the "Via" in register request looks like:
`Via: SIP/2.0/UDP 192.168.1.100:50001;rport;branch=z9hG4bK.iJM9FQ5m5ZRW0ZJZTAvNGlTyN9JPA6Nl`

The difference is that an extra "rport" is added. (See [RFC3581](https://www.[ietf.org/rfc/rfc3581.txt](https://www.ietf.org/rfc/rfc3581.txt)))

This allows the client to be in the NAT without causing message loss. This version of code works fine on my FreeSwitch server.

However, the code does not carefully tune the writing style and configuration features, perhaps adding additional configurable items would be better.